### PR TITLE
add udev trigger for device mapper nodes, etc.

### DIFF
--- a/lib/init/rc.boot
+++ b/lib/init/rc.boot
@@ -51,6 +51,7 @@ main() {
             udevd --daemon
             udevadm trigger --action=add --type=subsystems
             udevadm trigger --action=add --type=devices
+            udevadm trigger --action=change --type=devices
             udevadm settle
         }
     }


### PR DESCRIPTION
if necessary, creates the usual device mapper node symlinks at /dev/mapper/. for instance, dm-mod.create= will only create /dev/dm-X, and relies on udev for the rest.