### PR TITLE
Add rc.conf with rc.d for init hackers

### DIFF
--- a/etc/rc.conf
+++ b/etc/rc.conf
@@ -1,0 +1,4 @@
+#
+# rc.conf is loaded by /lib/init/rc.boot immediately after filesystems mounts
+# rc.conf is for config variables, while scripts may be placed in /etc/rc.d/
+#

--- a/etc/rc.conf
+++ b/etc/rc.conf
@@ -4,7 +4,7 @@
 #
 # Essentially, rc.conf is for config variables, and /etc/rc.d/ is for scripts.
 # Boot scripts should be suffixed with .boot
-# shutdown scripts should be suffixed with .pre.shutdown and .post.shutdown
+# Shutdown scripts should be suffixed with .pre.shutdown or .post.shutdown
 # All [executable] rc.d/ scripts are always exececuted. Please use caution.
 #
 # Example: Create a dmesg save script.

--- a/etc/rc.conf
+++ b/etc/rc.conf
@@ -10,5 +10,4 @@
 # Example: Create a dmesg save script.
 #
 # -> echo "dmesg > /var/log/dmesg.log" > /etc/rc.d/dmesg.boot
-#
 ###############################################################################

--- a/etc/rc.conf
+++ b/etc/rc.conf
@@ -1,4 +1,22 @@
+###############################################################################
+# rc.conf is loaded by /lib/init/rc.boot and /lib/init/rc.shutdown as early
+# as possible. Please inspect these scripts for more details.
 #
-# rc.conf is loaded by /lib/init/rc.boot immediately after filesystems mounts
-# rc.conf is for config variables, while scripts may be placed in /etc/rc.d/
+# Essentially, rc.conf is for config variables, and /etc/rc.d/ is for scripts.
+# Except for shutdown hooks, rc.d/ scripts should be suffixed with .sh
+# rc.d/ scripts when executable are always exececuted. Please use caution.
 #
+#                       --  /etc/rc.d/ examples --
+#
+# Example 1: The following creates a simple dmesg save boot script:
+#
+# -> echo "dmesg > /var/log/dmesg.log" > /etc/rc.d/dmesg.sh
+#
+# Example 2: Shutdown hooks must be prefixed with rc.shutdown_pre or
+#            rc.shutdown_post and must NOT be suffixed with .sh
+#
+# -> rc.shutdown_pre*  ==> e.g., rc.shutdown_pre_sinit_hook would be an
+# -> rc.shutdown_post*           acceptable name for a pre shutdown hook
+#                                required by sinit...
+#
+###############################################################################

--- a/etc/rc.conf
+++ b/etc/rc.conf
@@ -3,15 +3,12 @@
 # as possible. Please inspect these scripts for more details.
 #
 # Essentially, rc.conf is for config variables, and /etc/rc.d/ is for scripts.
-# Except for shutdown hooks, rc.d/ scripts should be suffixed with .sh
-# rc.d/ scripts when executable are always exececuted. Please use caution.
+# Boot scripts should be suffixed with .boot
+# shutdown scripts should be suffixed with .pre.shutdown and .post.shutdown
+# All [executable] rc.d/ scripts are always exececuted. Please use caution.
 #
-# Example 1: The following creates a simple dmesg save boot script,
-# -> echo "dmesg > /var/log/dmesg.log" > /etc/rc.d/dmesg.sh
+# Example: Create a dmesg save script.
 #
-# Example 2: Shutdown hooks must be prefixed with rc.shutdown_pre or
-#            rc.shutdown_post and must NOT be suffixed with .sh
-# -> rc.shutdown_pre*  ==> e.g., rc.shutdown_pre_sinit_hook would be an
-# -> rc.shutdown_post*           acceptable name for a pre shutdown hook
-#                                required by sinit...
+# -> echo "dmesg > /var/log/dmesg.log" > /etc/rc.d/dmesg.boot
+#
 ###############################################################################

--- a/etc/rc.conf
+++ b/etc/rc.conf
@@ -6,17 +6,12 @@
 # Except for shutdown hooks, rc.d/ scripts should be suffixed with .sh
 # rc.d/ scripts when executable are always exececuted. Please use caution.
 #
-#                       --  /etc/rc.d/ examples --
-#
-# Example 1: The following creates a simple dmesg save boot script:
-#
+# Example 1: The following creates a simple dmesg save boot script,
 # -> echo "dmesg > /var/log/dmesg.log" > /etc/rc.d/dmesg.sh
 #
 # Example 2: Shutdown hooks must be prefixed with rc.shutdown_pre or
 #            rc.shutdown_post and must NOT be suffixed with .sh
-#
 # -> rc.shutdown_pre*  ==> e.g., rc.shutdown_pre_sinit_hook would be an
 # -> rc.shutdown_post*           acceptable name for a pre shutdown hook
 #                                required by sinit...
-#
 ###############################################################################

--- a/etc/rc.conf
+++ b/etc/rc.conf
@@ -5,7 +5,7 @@
 # Essentially, rc.conf is for config variables, and /etc/rc.d/ is for scripts.
 # Boot scripts should be suffixed with .boot
 # Shutdown scripts should be suffixed with .pre.shutdown or .post.shutdown
-# All [executable] rc.d/ scripts are always exececuted. Please use caution.
+# All [executable] rc.d/ scripts are always executed. Please use caution.
 #
 # Example: Create a dmesg save script.
 #

--- a/etc/rc.conf
+++ b/etc/rc.conf
@@ -5,7 +5,6 @@
 # Essentially, rc.conf is for config variables, and /etc/rc.d/ is for scripts.
 # Boot scripts should be suffixed with .boot
 # Shutdown scripts should be suffixed with .pre.shutdown or .post.shutdown
-# All [executable] rc.d/ scripts are always executed. Please use caution.
 #
 # Example: Create a dmesg save script.
 #

--- a/lib/init/rc.boot
+++ b/lib/init/rc.boot
@@ -108,7 +108,9 @@ main() {
     }
 
     log "Loading rc.conf settings..."; {
-        [ -f /etc/rc.conf ] && . /etc/rc.conf
+        while read -r line; do
+            [ "${line##\#*}" ] && export "$line"
+        done < /etc/rc.conf
     }
 
     log "Checking filesystems..."; {
@@ -168,7 +170,7 @@ main() {
         done
     }
 
-    log "Running rc.d scripts..."; {
+    log "Running rc.d hooks..."; {
         for file in /etc/rc.d/*.boot; do
             [ -f "$file" ] && . "$file"
         done

--- a/lib/init/rc.boot
+++ b/lib/init/rc.boot
@@ -174,7 +174,7 @@ main() {
     log "Running rc.d scripts..."; {
         if [ -d /etc/rc.d ] ; then
             set +f
-            for file in /etc/rc.d/*.sh ; do
+            for file in /etc/rc.d/*.boot ; do
                 [ -x "$file" ] && . "$file"
             done
             set -f

--- a/lib/init/rc.boot
+++ b/lib/init/rc.boot
@@ -107,6 +107,10 @@ main() {
         }
     }
 
+    log "Loading rc.conf settings..."; {
+        [ -f "/etc/rc.conf" ] && . /etc/rc.conf
+    }
+
     log "Checking filesystems..."; {
         fsck -ATat noopts=_netdev
         [ $? -gt 1 ] && emergency_shell
@@ -166,6 +170,17 @@ main() {
 
     command -v udevd >/dev/null &&
         udevadm control --exit
+
+    log "Running rc.d scripts..."; {
+        if [ -d /etc/rc.d ] ; then
+            set +f
+            for file in /etc/rc.d/*.sh ; do
+                [ -x "$file" ] && . "$file"
+            done
+            unset file
+            set -f
+        fi
+    }
 
     log "Boot stage complete..."
 }

--- a/lib/init/rc.boot
+++ b/lib/init/rc.boot
@@ -168,16 +168,14 @@ main() {
         done
     }
 
-    command -v udevd >/dev/null &&
-        udevadm control --exit
-
     log "Running rc.d scripts..."; {
-        set +f
-        for file in /etc/rc.d/*.boot ; do
+        for file in /etc/rc.d/*.boot; do
             [ -f "$file" ] && . "$file"
         done
-        set -f
     }
+
+    command -v udevd >/dev/null &&
+        udevadm control --exit
 
     log "Boot stage complete..."
 }

--- a/lib/init/rc.boot
+++ b/lib/init/rc.boot
@@ -108,7 +108,7 @@ main() {
     }
 
     log "Loading rc.conf settings..."; {
-        [ -f "/etc/rc.conf" ] && . /etc/rc.conf
+        [ -f /etc/rc.conf ] && . /etc/rc.conf
     }
 
     log "Checking filesystems..."; {

--- a/lib/init/rc.boot
+++ b/lib/init/rc.boot
@@ -172,13 +172,11 @@ main() {
         udevadm control --exit
 
     log "Running rc.d scripts..."; {
-        if [ -d /etc/rc.d ] ; then
-            set +f
-            for file in /etc/rc.d/*.boot ; do
-                [ -x "$file" ] && . "$file"
-            done
-            set -f
-        fi
+        set +f
+        for file in /etc/rc.d/*.boot ; do
+            [ -f "$file" ] && . "$file"
+        done
+        set -f
     }
 
     log "Boot stage complete..."

--- a/lib/init/rc.boot
+++ b/lib/init/rc.boot
@@ -177,7 +177,6 @@ main() {
             for file in /etc/rc.d/*.sh ; do
                 [ -x "$file" ] && . "$file"
             done
-            unset file
             set -f
         fi
     }

--- a/lib/init/rc.shutdown
+++ b/lib/init/rc.shutdown
@@ -50,8 +50,6 @@ main() {
     }
 }
 
-set +f
-
 for file in /etc/rc.d/*.pre.shutdown ; do
     [ -f "$file" ] && . "$file"
 done

--- a/lib/init/rc.shutdown
+++ b/lib/init/rc.shutdown
@@ -46,4 +46,14 @@ main() {
     }
 }
 
+set +f
+
+for file in /etc/rc.d/rc.shutdown_pre* ; do
+    [ -x "$file" ] && . "$file"
+done
+
 main
+
+for file in /etc/rc.d/rc.shutdown_post* ; do
+    [ -x "$file" ] && . "$file"
+done

--- a/lib/init/rc.shutdown
+++ b/lib/init/rc.shutdown
@@ -50,12 +50,12 @@ main() {
     }
 }
 
-for file in /etc/rc.d/*.pre.shutdown ; do
+for file in /etc/rc.d/*.pre.shutdown; do
     [ -f "$file" ] && . "$file"
 done
 
 main
 
-for file in /etc/rc.d/*.post.shutdown ; do
+for file in /etc/rc.d/*.post.shutdown; do
     [ -f "$file" ] && . "$file"
 done

--- a/lib/init/rc.shutdown
+++ b/lib/init/rc.shutdown
@@ -48,12 +48,16 @@ main() {
 
 set +f
 
-for file in /etc/rc.d/rc.shutdown_pre* ; do
-    [ -x "$file" ] && . "$file"
-done
+if [ -d /etc/rc.d ] ; then
+    for file in /etc/rc.d/rc.shutdown_pre* ; do
+        [ -x "$file" ] && . "$file"
+    done
+fi
 
 main
 
-for file in /etc/rc.d/rc.shutdown_post* ; do
-    [ -x "$file" ] && . "$file"
-done
+if [ -d /etc/rc.d ] ; then
+    for file in /etc/rc.d/rc.shutdown_post* ; do
+        [ -x "$file" ] && . "$file"
+    done
+fi

--- a/lib/init/rc.shutdown
+++ b/lib/init/rc.shutdown
@@ -7,6 +7,10 @@ log() {
 main() {
     PATH=/sbin:/bin:/usr/sbin:/usr/bin
 
+    log "Loading rc.conf settings..."; {
+        [ -f /etc/rc.conf ] && . /etc/rc.conf
+    }
+
     log "Waiting for services to stop..."; {
         sv -w196 force-stop /var/service/*
         sv exit /var/service/*

--- a/lib/init/rc.shutdown
+++ b/lib/init/rc.shutdown
@@ -53,7 +53,7 @@ main() {
 set +f
 
 if [ -d /etc/rc.d ] ; then
-    for file in /etc/rc.d/rc.shutdown_pre* ; do
+    for file in /etc/rc.d/*.pre.shutdown ; do
         [ -x "$file" ] && . "$file"
     done
 fi
@@ -61,7 +61,7 @@ fi
 main
 
 if [ -d /etc/rc.d ] ; then
-    for file in /etc/rc.d/rc.shutdown_post* ; do
+    for file in /etc/rc.d/*.post.shutdown ; do
         [ -x "$file" ] && . "$file"
     done
 fi

--- a/lib/init/rc.shutdown
+++ b/lib/init/rc.shutdown
@@ -52,16 +52,12 @@ main() {
 
 set +f
 
-if [ -d /etc/rc.d ] ; then
-    for file in /etc/rc.d/*.pre.shutdown ; do
-        [ -x "$file" ] && . "$file"
-    done
-fi
+for file in /etc/rc.d/*.pre.shutdown ; do
+    [ -f "$file" ] && . "$file"
+done
 
 main
 
-if [ -d /etc/rc.d ] ; then
-    for file in /etc/rc.d/*.post.shutdown ; do
-        [ -x "$file" ] && . "$file"
-    done
-fi
+for file in /etc/rc.d/*.post.shutdown ; do
+    [ -f "$file" ] && . "$file"
+done

--- a/lib/init/rc.shutdown
+++ b/lib/init/rc.shutdown
@@ -8,7 +8,15 @@ main() {
     PATH=/sbin:/bin:/usr/sbin:/usr/bin
 
     log "Loading rc.conf settings..."; {
-        [ -f /etc/rc.conf ] && . /etc/rc.conf
+        while read -r line; do
+            [ "${line##\#*}" ] && export "$line"
+        done < /etc/rc.conf
+    }
+
+    log "Running shutdown pre hooks..."; {
+        for file in /etc/rc.d/*.pre.shutdown; do
+            [ -f "$file" ] && . "$file"
+        done
     }
 
     log "Waiting for services to stop..."; {
@@ -48,14 +56,12 @@ main() {
             done
         }
     }
+
+    log "Running shutdown post hooks..." {
+        for file in /etc/rc.d/*.post.shutdown; do
+            [ -f "$file" ] && . "$file"
+        done
+    }
 }
 
-for file in /etc/rc.d/*.pre.shutdown; do
-    [ -f "$file" ] && . "$file"
-done
-
 main
-
-for file in /etc/rc.d/*.post.shutdown; do
-    [ -f "$file" ] && . "$file"
-done


### PR DESCRIPTION
Packaging sinit https://github.com/kisslinux/community/pull/200 requires this, and it could be useful for other ideas,

For example, if you decide to rehash the rc.boot script, you could make a lot of it toggle-able options, which can be switched and diddled with by the user's settings in rc.conf