### PR TITLE
rc.boot: seed random after root is mounted read-write

### DIFF
--- a/lib/init/rc.boot
+++ b/lib/init/rc.boot
@@ -34,17 +34,6 @@ log "Mounting pseudo filesystems..."; {
     ln -sf fd/2 /dev/stderr
 }
 
-log "Seeding random..."; {
-    if [ -f /var/random.seed ]; then
-        cat /var/random.seed > /dev/urandom
-    else
-        log "This may hang."
-        log "Mash the keyboard to generate entropy..."
-
-        dd count=1 bs=512 if=/dev/random of=/var/random.seed
-    fi
-}
-
 log "Starting device manager..."; {
     if command -v udevd >/dev/null; then
         log "Starting udevd..."
@@ -149,6 +138,17 @@ log "Mounting all local filesystems..."; {
 
 log "Enabling swap..."; {
     swapon -a || emergency_shell
+}
+
+log "Seeding random..."; {
+    if [ -f /var/random.seed ]; then
+        cat /var/random.seed > /dev/urandom
+    else
+        log "This may hang."
+        log "Mash the keyboard to generate entropy..."
+
+        dd count=1 bs=512 if=/dev/random of=/var/random.seed
+    fi
 }
 
 log "Setting up loopback..."; {


### PR DESCRIPTION
Since grub config mounts root read-only by default, first system boot happens with message `dd: can't open /var/random.seed: Read-only file system`.
Moved seed phase until after filesystems are mounted.