### PR TITLE
mdev: create /dev/mapper nodes

### DIFF
--- a/lib/init/rc.boot
+++ b/lib/init/rc.boot
@@ -61,6 +61,9 @@ log "Starting device manager..."; {
         printf '/bin/mdev\n' > /proc/sys/kernel/hotplug
         mdev -s
 
+        # Create /dev/mapper nodes
+        [ -x /bin/dmsetup ] && dmsetup mknodes
+
         # Handle Network interfaces.
         for file in /sys/class/net/*/uevent; do
             printf 'add\n' > "$file"


### PR DESCRIPTION
lvm2 can indeed be run without eudev, but it needs to be compiled without (at least) `--enable-udev_sync`. I also compiled successfully without `--enable-udev_rules`.