### PR TITLE
inittab: fix getty not spawning in tty1

### DIFF
--- a/etc/inittab
+++ b/etc/inittab
@@ -3,13 +3,13 @@
 ::shutdown:/lib/init/rc.shutdown
 ::respawn:runsvdir -P /var/service 'log: ................................................................................................................................................................................................................................................................'
 
-tty1::respawn:/bin/getty 38400 tty2
-tty2::respawn:/bin/getty 38400 tty3
+tty1::respawn:/bin/getty 38400 tty1
+tty2::respawn:/bin/getty 38400 tty2
 
 # Uncomment to enable more gettys.
-# tty3::respawn:/bin/getty 38400 tty4
-# tty4::respawn:/bin/getty 38400 tty5
-# tty5::respawn:/bin/getty 38400 tty6
+# tty3::respawn:/bin/getty 38400 tty3
+# tty4::respawn:/bin/getty 38400 tty4
+# tty5::respawn:/bin/getty 38400 tty5
 
 # Login directly as a user and bypass the login prompt.
 # NOTE: This bypasses the use of a getty altogether.


### PR DESCRIPTION
Following up https://freenode.logbot.info/kisslinux/20200519#c3917142, I discovered that getty actually spawns in tty2 and tty3, and nothing spawns on tty1. This is why KISS init seems to hang after completing boot stage.