### PR TITLE
rc.shutdown: fix premature unmounting of pseudo-filesystems

### DIFF
--- a/lib/init/rc.shutdown
+++ b/lib/init/rc.shutdown
@@ -42,7 +42,7 @@ log "Unmounting filesystems and disabling swap..."; {
     # This flag is unsupported by ubase and I consider this
     # a ubase issue. ubase only supports Linux and this
     # flag is a part of the Linux standard base.
-    umount -rat nosysfs,noproc,nodevtmpfs,notmpfs
+    umount -rat nosysfs,proc,devtmpfs,tmpfs
 }
 
 log "Remounting rootfs as read-only"; {


### PR DESCRIPTION
When passing the `-t` flag to umount, the "no" prefix applies to the whole list of fs types, not just the one that it prefixes (see umount man page or libbb/match_fstype.c in busybox source code). Currently, umount tries to ignore "noproc", "nodevtmpfs" and "notmpfs", due to the "no" prefix on "sysfs". They obviously do not match "proc", "devtmpfs" and "tmpfs", meaning these filesystems get unintentionally and prematurely unmounted. This leads to errors about not being able to read `/proc/mounts` on shutdown.

This fixes the issue by correctly prefixing just the whole list, rather than each filesystem type.